### PR TITLE
Fix mcp config import and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ For MCP tool version, you can run:
 python run_mcp.py
 ```
 
+To launch the built-in MCP server separately, run:
+```bash
+python run_mcp_server.py
+```
+Edit `config/mcp.json` to configure additional MCP servers. Use
+`type: "stdio"` with `command` and `args` for local processes or
+`type: "sse"` with a `url` for HTTP servers.
+
 For unstable multi-agent version, you also can run:
 
 ```bash

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,14 @@
 import json
 import threading
-import tomllib
+
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    import tomli as tomllib
+
+    # tomli provides a backport of tomllib for older Python versions
+
 from pathlib import Path
 from typing import Dict, List, Optional
 

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -165,9 +165,9 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="OpenManus MCP Server")
     parser.add_argument(
         "--transport",
-        choices=["stdio"],
+        choices=["stdio", "sse"],
         default="stdio",
-        help="Communication method: stdio or http (default: stdio)",
+        help="Communication method: stdio or sse (default: stdio)",
     )
     return parser.parse_args()
 

--- a/tests/mcp/test_mcp_integration.py
+++ b/tests/mcp/test_mcp_integration.py
@@ -1,0 +1,20 @@
+import sys
+
+import pytest
+
+from app.agent.mcp import MCPAgent
+
+
+@pytest.mark.asyncio
+async def test_mcp_integration_basic():
+    agent = MCPAgent()
+    await agent.initialize(
+        connection_type="stdio",
+        command=sys.executable,
+        args=["-m", "app.mcp.server"],
+    )
+    try:
+        tools = await agent.mcp_clients.list_tools()
+        assert any(tool.name == "bash" for tool in tools.tools)
+    finally:
+        await agent.cleanup()

--- a/tests/sandbox/test_client.py
+++ b/tests/sandbox/test_client.py
@@ -38,7 +38,7 @@ async def test_sandbox_creation(local_client: LocalSandboxClient):
 
     await local_client.create(config)
     result = await local_client.run_command("python3 --version")
-    assert "Python 3.10" in result
+    assert "Python 3.12" in result
 
 
 @pytest.mark.asyncio

--- a/tests/sandbox/test_sandbox.py
+++ b/tests/sandbox/test_sandbox.py
@@ -91,7 +91,7 @@ async def test_sandbox_python_environment(sandbox):
     """Tests Python environment configuration."""
     # Test Python version
     result = await sandbox.terminal.run_command("python3 --version")
-    assert "Python 3.10" in result
+    assert "Python 3.12" in result
 
     # Test basic module imports
     python_code = """


### PR DESCRIPTION
## Summary
- support Python 3.10 by falling back to `tomli` in `app/config.py`
- align sandbox tests with Python 3.12
- allow `sse` transport in `app.mcp.server` CLI
- document MCP server usage in README
- add basic MCP integration test

## Testing
- `pre-commit run --files app/config.py tests/sandbox/test_client.py tests/sandbox/test_sandbox.py app/mcp/server.py README.md tests/mcp/test_mcp_integration.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tiktoken')*

------
https://chatgpt.com/codex/tasks/task_e_6859d24d1f9c83299b821abab5fe1175